### PR TITLE
Added missing Info.plist item

### DIFF
--- a/Sources/SwiftUIApp/FOSShowcase-Info.plist
+++ b/Sources/SwiftUIApp/FOSShowcase-Info.plist
@@ -9,5 +9,9 @@
 	</dict>
 	<key>CFBundleIconName</key>
 	<string>AppIcon</string>
+	<key>CFBundleIcons.CFBundlePrimaryIcon</key>
+	<string>AppIcon</string>
+	<key>CFBundlePrimaryIcon</key>
+	<string>AppIcon</string>
 </dict>
 </plist>


### PR DESCRIPTION
- CFBundleIcons.CFBundlePrimaryIcon seems to be unique to visionOS??