### PR TITLE
Set AppStore Connect encryption compliance values

### DIFF
--- a/Sources/SwiftUIApp/FOSShowcase-Info.plist
+++ b/Sources/SwiftUIApp/FOSShowcase-Info.plist
@@ -7,6 +7,8 @@
 		<key>UIImageName</key>
 		<string>AppIcon</string>
 	</dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleIcons</key>
 	<dict>
 		<key>CFBundlePrimaryIcon</key>


### PR DESCRIPTION
- This will allow the app to be auto distributed on TestFlight once Xcode Cloud Build is complete.